### PR TITLE
Fix responsive layout

### DIFF
--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -12,8 +12,8 @@ export default function Header() {
           <Link to="/" className="mb-4 sm:mb-0">
             <Logo />
           </Link>
-          <nav className="z-50 bg-white border-slate-200 fixed bottom-0 left-0 border-t py-3 w-full text-base sm:border-t-0 sm:w-96 sm:relative md:border-0">
-            <div className="flex flex-nowrap w-1/2 items-center justify-between mx-auto sm:justify-right sm:mr-0 sm:ml-auto">
+          <nav className="z-50 bg-white border-slate-200 fixed bottom-0 left-0 border-t py-3 w-full text-base sm:border-t-0 sm:w-2/4 sm:relative md:border-0">
+            <div className="flex flex-nowrap w-full items-center justify-between mx-auto sm:justify-end sm:mr-0 sm:ml-auto">
               <Link to="/cart" className="mr-5 mt-1 hover:text-gray-900 md:mr-6">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -33,7 +33,7 @@ export default function Header() {
                     alt=""
                     />
                   </Link>
-                  {/* <Link to="/profile" className="hidden md:block">{user?.displayName}</Link> */}
+                  <Link to="/profile" className="hidden md:block">{user?.displayName}</Link>
                 </span>
               ) : (
                 <Link

--- a/src/Pages/FoodDetails.jsx
+++ b/src/Pages/FoodDetails.jsx
@@ -15,7 +15,7 @@ export default function FoodDetails() {
   return (
     <>
       <Header />
-      <div className="container mx-auto -mt-8">
+      <div className="container mx-auto">
         <Link
           className="hover:underline poppins text-gray-700 mb-5 md:mb-1 select-none flex items-center space-x-2"
           to="/"


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #2 

Additional styling tweaks to address the issue of longer usernames names not displaying properly (see pull request #5 discussion.) (Also added a suggested change to the margin on the FoodDetails page - the 'back' navigation looks more balanced when its top margin matches the left margin.)